### PR TITLE
correct set seed

### DIFF
--- a/episodes/2-keras.Rmd
+++ b/episodes/2-keras.Rmd
@@ -276,8 +276,7 @@ Therefore we will need to set two random seeds, one for numpy and one for tensor
 ```python
 from numpy.random import seed
 seed(1)
-from tensorflow.random import set_seed
-set_seed(2)
+keras.utils.set_random_seed(2)
 ```
 
 ### Build a neural network from scratch


### PR DESCRIPTION
This PR fixes the seed setting for keras.

the `from tensorflow.random import set_seed` does not work to ensure consistent results.
Setting `keras.utils.set_random_seed(2)` does work (in combination with the numpy.random.seed)